### PR TITLE
fix: add session cancellation support via context for improved connection management

### DIFF
--- a/common/constant/constant.go
+++ b/common/constant/constant.go
@@ -20,6 +20,8 @@ const (
 	ContextPortMapKey       = ContextKeyType(0x01)
 	ContextLastKeepAliveKey = ContextKeyType(0x02)
 	ContextSignalChanKey    = ContextKeyType(0x03)
+	// ContextSessionCancelKey stores a context.CancelFunc for per-session cancellation on server side
+	ContextSessionCancelKey = ContextKeyType(0x04)
 )
 
 var LogLevelMap = map[string]log.Level{

--- a/server/server.go
+++ b/server/server.go
@@ -92,6 +92,8 @@ func handleSession(ctx context.Context, wg *sync.WaitGroup, config *config.Serve
 	defer wg.Done()
 	// Create a cancellable context for this session
 	sessionCtx, sessionCancel := context.WithCancel(ctx)
+	// Store cancel func in context so helper utilities (CancelConnection) can terminate session without relying on signal channel
+	sessionCtx = context.WithValue(sessionCtx, C.ContextSessionCancelKey, sessionCancel)
 	defer sessionCancel()
 
 	// Cleanup function to ensure resources are properly released


### PR DESCRIPTION
This pull request introduces improvements to session cancellation handling in the server code. The main change is the addition of a per-session cancellation mechanism using `context.CancelFunc`, which allows for more reliable and flexible session termination. The existing signal channel approach is retained for backwards compatibility.

Session cancellation enhancements:

* Added a new constant `ContextSessionCancelKey` in `common/constant/constant.go` to store a `context.CancelFunc` for per-session cancellation.
* Updated session handling in `server/server.go` to store the session's cancel function in the context, enabling utilities like `CancelConnection` to terminate sessions directly.

Backwards compatibility and refactoring:

* Refactored the `CancelConnection` function in `server/control.go` to first attempt session cancellation via the new cancel function, and fall back to the legacy signal channel if necessary. Improved logging for each cancellation path.