### PR TITLE
fix: update SourceMap type to use string keys for UDPPortListener for enhanced robustness

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -24,18 +24,18 @@ type LogConfig struct {
 }
 
 type ClientTransportConfig struct {
-	Protocol   string `json:"protocol,omitempty"`      // "quic" or "tcp"
-	IP         string `json:"server_ip,omitempty"`     // Server IP
-	Port       int    `json:"server_port,omitempty"`   // Server Port
-	CAFile     string `json:"ca_file,omitempty"`       // Path to CA file
+	Protocol   string `json:"protocol,omitempty"`    // "quic" or "tcp"
+	IP         string `json:"server_ip,omitempty"`   // Server IP
+	Port       int    `json:"server_port,omitempty"` // Server Port
+	CAFile     string `json:"ca_file,omitempty"`     // Path to CA file
 	ServerName string `json:"server_name,omitempty"` // SNI
 }
 
 type ServerTransportConfig struct {
-	Protocol string `json:"protocol,omitempty"`    // "quic" or "tcp"
-	Port     int    `json:"port,omitempty"`        // Server Port
+	Protocol string `json:"protocol,omitempty"`  // "quic" or "tcp"
+	Port     int    `json:"port,omitempty"`      // Server Port
 	CertFile string `json:"cert_file,omitempty"` // Path to certificate file
-	KeyFile  string `json:"key_file,omitempty"`    // Path to key file
+	KeyFile  string `json:"key_file,omitempty"`  // Path to key file
 }
 
 type ServerConnectionConfig struct {

--- a/common/constant/function.go
+++ b/common/constant/function.go
@@ -72,12 +72,12 @@ func NewBidirectionalPipePair() (*BidirectionalPipe, *BidirectionalPipe) {
 	reader1, writer1 := io.Pipe()
 	reader2, writer2 := io.Pipe()
 	return &BidirectionalPipe{
-		Reader: reader1,
-		Writer: writer2,
-	}, &BidirectionalPipe{
-		Reader: reader2,
-		Writer: writer1,
-	}
+			Reader: reader1,
+			Writer: writer2,
+		}, &BidirectionalPipe{
+			Reader: reader2,
+			Writer: writer1,
+		}
 }
 
 func (pw *BidirectionalPipe) Read(b []byte) (n int, err error) {
@@ -99,5 +99,5 @@ func (pw *BidirectionalPipe) Close() error {
 
 func IsQUICHandshake(data []byte) bool {
 	// Check if the packet contains a long header
-	return data[0] & 0xC0 == 0xC0
+	return data[0]&0xC0 == 0xC0
 }

--- a/common/constant/type.go
+++ b/common/constant/type.go
@@ -1,9 +1,9 @@
 package constant
 
 import (
-	"fmt"
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"neofrp/common/multidialer"
 	"net"
@@ -49,12 +49,12 @@ func (tp *TaggedPort) String() string {
 func (tp *TaggedPort) Bytes() []byte {
 	// use big endian encoding
 	switch tp.PortType {
-		case "tcp":
-			return []byte{PortTypeTCP, byte(tp.Port >> 8), byte(tp.Port & 0xFF)}
-		case "udp":
-			return []byte{PortTypeUDP, byte(tp.Port >> 8), byte(tp.Port & 0xFF)}
-		default:
-			return nil
+	case "tcp":
+		return []byte{PortTypeTCP, byte(tp.Port >> 8), byte(tp.Port & 0xFF)}
+	case "udp":
+		return []byte{PortTypeUDP, byte(tp.Port >> 8), byte(tp.Port & 0xFF)}
+	default:
+		return nil
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -247,7 +247,7 @@ func SetupPorts(ctx context.Context, config *config.ServerConfig) error {
 		udpListener := &UDPPortListener{
 			TaggedPort: taggedPort,
 			PortMap:    portMap,
-			SourceMap:  safemap.NewSafeMap[*net.UDPAddr, *multidialer.Stream](),
+			SourceMap:  safemap.NewSafeMap[string, *multidialer.Stream](),
 		}
 		err := udpListener.Start()
 		if err != nil {


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the multiplexed stream handling and port listener logic, focusing on data integrity, error handling, and diagnostics. The main changes ensure atomic writes, correct stream lifecycle management, improved error logging, and consistent UDP stream mapping. Below are the most important changes grouped by theme.

### Multiplexed TCP Stream Reliability and Diagnostics

* Added a `writeMu` mutex to `tcpSession` and updated `writeFrame` to serialize frame writes, guaranteeing atomic header+payload writes and handling partial writes to avoid interleaving/corruption. [[1]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7R189) [[2]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7R326-R342) [[3]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7L340-R382)
* Modified stream closure logic: streams are only removed after receiving a remote zero-length frame (EOF), ensuring proper shutdown coordination and preventing premature removal. [[1]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7R326-R342) [[2]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7R497-R503)
* Added debug instrumentation for new streams, logging the first frame bytes and stream ID for improved diagnostics. [[1]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7R307-R314) [[2]](diffhunk://#diff-1d0827c6e9836c14c6fdf15d6c3bed0b745a353e6ef8e0e54fd4fc46bd6e32a7R415-R417)

### Error Handling and Logging Improvements

* Introduced `isUseOfClosedErr` helper to distinguish benign network closure errors, reducing unnecessary error logs and improving shutdown handling. [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R151-R159) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L252-R304)
* Enhanced error reporting when reading stream headers and handling unknown port types, including additional diagnostics such as stream ID and extra bytes for troubleshooting. [[1]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L186-R204) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L202-R241)

### Port Listener Robustness

* Ensured full write of the 3-byte tagged port header for both TCP and UDP listeners, with validation and instrumentation for stream ID and port. Improved error handling for partial writes and invalid header lengths. [[1]](diffhunk://#diff-bfb2d420f90f8bc0b6b3d8f9f75dc93a2d3859e6fd86ce17fd9b45891d398b76L87-R109) [[2]](diffhunk://#diff-bfb2d420f90f8bc0b6b3d8f9f75dc93a2d3859e6fd86ce17fd9b45891d398b76L198-R247)
* Updated UDP port listener to use string keys for `SourceMap` instead of `*net.UDPAddr`, ensuring consistent mapping and cleanup of streams. [[1]](diffhunk://#diff-bfb2d420f90f8bc0b6b3d8f9f75dc93a2d3859e6fd86ce17fd9b45891d398b76L126-R142) [[2]](diffhunk://#diff-bfb2d420f90f8bc0b6b3d8f9f75dc93a2d3859e6fd86ce17fd9b45891d398b76L150-R174) [[3]](diffhunk://#diff-bfb2d420f90f8bc0b6b3d8f9f75dc93a2d3859e6fd86ce17fd9b45891d398b76L198-R247) [[4]](diffhunk://#diff-bfb2d420f90f8bc0b6b3d8f9f75dc93a2d3859e6fd86ce17fd9b45891d398b76L227-R260) [[5]](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4L250-R250)

These changes collectively improve the reliability, maintainability, and observability of the multiplexed stream and port forwarding infrastructure.